### PR TITLE
Changed from AWS basic authentication to DefaultAWSCredentialsProviderChain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@ target
 .classpath
 .java-version
 *.iml
+.DS_Store
+s3/.DS_Store
+s3/src/.DS_Store
+s3/src/main/.DS_Store
+s3/src/main/java/.DS_Store
+s3/src/main/java/com/.DS_Store
+s3/src/main/java/com/instaclustr/.DS_Store
+s3/src/main/java/com/instaclustr/kafka/.DS_Store
+s3/src/main/java/com/instaclustr/kafka/connect/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,3 @@ target
 .java-version
 *.iml
 .DS_Store
-s3/.DS_Store
-s3/src/.DS_Store
-s3/src/main/.DS_Store
-s3/src/main/java/.DS_Store
-s3/src/main/java/com/.DS_Store
-s3/src/main/java/com/instaclustr/.DS_Store
-s3/src/main/java/com/instaclustr/kafka/.DS_Store
-s3/src/main/java/com/instaclustr/kafka/connect/.DS_Store

--- a/s3/src/main/java/com/instaclustr/kafka/connect/s3/AwsStorageConnectorCommonConfig.java
+++ b/s3/src/main/java/com/instaclustr/kafka/connect/s3/AwsStorageConnectorCommonConfig.java
@@ -21,11 +21,7 @@ public class AwsStorageConnectorCommonConfig {
 
     public static final String AWS_REGION = "aws.region";
 
-    public static final String S3_KEY_PREFIX = "prefix";
-
-    public static final String AWS_SECRET_KEY = "aws.secretKey";
-
-    public static final String AWS_ACCESS_KEY_ID = "aws.accessKeyId";
+    public static final String S3_KEY_PREFIX = "prefix"; 
 
     public static final String DEFAULT_AWS_REGION = Regions.DEFAULT_REGION.getName();
 
@@ -36,8 +32,6 @@ public class AwsStorageConnectorCommonConfig {
         configDef.define(BUCKET, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, "Name of the S3 bucket")
                 .define(S3_KEY_PREFIX, ConfigDef.Type.STRING, "", new RegexStringValidator(Pattern.compile("^$|[-a-zA-Z0-9_./]+$"), "prefix can only contain alphanumerics, underscores(_), hyphens(-), periods(.) and slashes(/) only."),
                         ConfigDef.Importance.HIGH, "Path prefix for the objects written into S3")
-                .define(AWS_ACCESS_KEY_ID, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, "AWS access key id")
-                .define(AWS_SECRET_KEY, ConfigDef.Type.PASSWORD, ConfigDef.Importance.HIGH, "AWS access secret key")
                 .define(AWS_REGION, ConfigDef.Type.STRING, DEFAULT_AWS_REGION, ConfigDef.Importance.MEDIUM, String.format("AWS client region, if not set will use %s", DEFAULT_AWS_REGION));
         return configDef;
     }
@@ -69,12 +63,12 @@ public class AwsStorageConnectorCommonConfig {
             s3Client.shutdown();
         } catch (AmazonS3Exception e) {
             switch (e.getErrorCode()) {
-                case "InvalidAccessKeyId":
-                    addErrorMessageToConfigObject(configObject, AWS_ACCESS_KEY_ID, "The defined aws.accessKeyId is invalid");
-                    break;
-                case "SignatureDoesNotMatch":
-                    addErrorMessageToConfigObject(configObject, AWS_SECRET_KEY, "The defined aws.secretKey is invalid");
-                    break;
+	            case "InvalidAccessKeyId":
+	                addErrorMessageToConfigObject(configObject, "", "The AWS AccessKeyId is invalid");
+	                break;
+	            case "SignatureDoesNotMatch":
+	                addErrorMessageToConfigObject(configObject, "", "The AWS SecretKey is invalid");
+	                break;
                 case "InvalidBucketName":
                     addErrorMessageToConfigObject(configObject, BUCKET, "The defined bucket name is invalid");
                     break;

--- a/s3/src/main/java/com/instaclustr/kafka/connect/s3/TransferManagerProvider.java
+++ b/s3/src/main/java/com/instaclustr/kafka/connect/s3/TransferManagerProvider.java
@@ -1,6 +1,7 @@
 package com.instaclustr.kafka.connect.s3;
 
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Regions;
@@ -27,12 +28,10 @@ public class TransferManagerProvider {
     }
 
     public static AmazonS3ClientBuilder getS3ClientBuilderWithRegionAndCredentials(final Map<String, String> config) {
-        String accessKey = getFromConfigOrEnvironment(config, AwsStorageConnectorCommonConfig.AWS_ACCESS_KEY_ID);
-        String secret = getFromConfigOrEnvironment(config, AwsStorageConnectorCommonConfig.AWS_SECRET_KEY);
         String region = getFromConfigOrEnvironment(config, AwsStorageConnectorCommonConfig.AWS_REGION);
 
         AmazonS3ClientBuilder clientBuilder = AmazonS3ClientBuilder.standard()
-                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secret)));
+                .withCredentials(new DefaultAWSCredentialsProviderChain());
 
         if (region == null) {
             region = AwsStorageConnectorCommonConfig.DEFAULT_AWS_REGION;


### PR DESCRIPTION
Currently, Open source Kafka connector(https://github.com/instaclustr/kafka-connect-connectors) uses AWS credentials supplying arguments to connect AWS S3. 

We are modifying without supplying any arguments to find AWS credentials by using `DefaultAWSCredentialsProviderChain` 

Ref : https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html

